### PR TITLE
Updated N-Labs preset and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,7 @@
 One json file containing waypoint presets for various maps, automatically fetched from Rigs of Rods to use with the AI.
 
 # Contribute
-Open survey map (TAB) and use right mouse button to set waypoints. Use middle mouse button to remove them. Drag an existing waypoint with left mouse button to re-adjust it.
-
-![kk](https://user-images.githubusercontent.com/2660424/192834582-f0e94e3b-9b3a-4bd7-bba4-acd2fbb2f4bb.png)
-
-Once done, press the `Start` button to test the path. Finally click the `Waypoints` header and press the `Export` button. A notififation will appear and the waypoints will be saved in `RoR.log`.
-
-Open an issue in this repository and provide the waypoints list and desired preset name. Pull requests are welcomed also, the json file is very simple structured.
+If you wish to contribute, please see this guide on our [Documentation](https://docs.rigsofrods.org/gameplay/vehicle-ai/#creating-waypoint-presets). 
 
 # Load local file
 Put `waypoints.json` inside `Documents\My Games\Rigs of Rods\savegames` on Windows or `~/.rigsofrods/savegames` on Linux. Rigs of Rods will load that file instead of fetching from GitHub.

--- a/waypoints.json
+++ b/waypoints.json
@@ -10091,7 +10091,17 @@
 
     {
         "terrain":"CM.terrn2",
-        "preset":"Center Ramp Crash",
+        "preset":"Center Ramp",
+        "waypoints":
+        [
+            [265.596985, 0.100000, 499.421204],
+            [265.596985, 0.100000, 124.750999]
+        ]
+    },
+
+    {
+        "terrain":"CM.terrn2",
+        "preset":"Center Ramp (Crash Mode)",
         "waypoints":
         [
             [265.597,    0.100,  387.206],


### PR DESCRIPTION
Added a second 'Center Ramp' preset which spawns a vehicle further away, renamed other preset to 'Center Ramp (Crash Mode)' 

Also replaced the contributing section of the README with a link to the new Docs page.